### PR TITLE
chore: upgrade GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:  # Allow manual trigger from GitHub UI
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   NODE_VERSION: '22'
   PYTHON_VERSION: '3.11'
   RESUME_FILENAME_BASE: 'kenzik-resume'
@@ -21,7 +22,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       # ========================================
       # Create Private Resume Data from Secret
@@ -38,7 +39,7 @@ jobs:
       # Python: Build Resume Documents
       # ========================================
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -77,7 +78,7 @@ jobs:
       # Node.js: Build Web Application
       # ========================================
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,6 +20,7 @@ on:
         type: string
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   NODE_VERSION: '22'
   PYTHON_VERSION: '3.11'
   RESUME_FILENAME_BASE: 'kenzik-resume'
@@ -35,7 +36,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       # ========================================
       # Create Private Resume Data from Secret
@@ -52,7 +53,7 @@ jobs:
       # Python: Build Resume Documents
       # ========================================
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -100,7 +101,7 @@ jobs:
       # Node.js: Build Web Application
       # ========================================
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
@@ -147,7 +148,7 @@ jobs:
       
       - name: Comment Preview URL on PR
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const url = '${{ steps.deploy.outputs.deployment-url }}';


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v4 → v6, `actions/setup-python` v5 → v6, `actions/setup-node` v4 → v6, `actions/github-script` v7 → v8 for Node 24 support
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` env var to both workflows as a safety net for third-party actions (`cloudflare/wrangler-action@v3`)
- Addresses the Node.js 20 deprecation warning ahead of the June 2, 2026 mandatory migration

## Test plan
- [ ] Verify deploy workflow runs successfully on next version tag
- [ ] Verify preview workflow runs on next PR

Made with [Cursor](https://cursor.com)