### PR TITLE
docs: add 2026 design vision and agent roster

### DIFF
--- a/.claude/agents/a11y-engineer.md
+++ b/.claude/agents/a11y-engineer.md
@@ -1,0 +1,44 @@
+---
+name: a11y-engineer
+description: >-
+  Accessibility engineer. Use for ARIA attributes, focus management, keyboard
+  affordances, reduced-motion media-query wiring, and screen-reader behavior of
+  the terminal UI. Frames accessibility as period-correct hardware features per
+  DESIGN_GUIDE_2026-2.md §7 — never as bolted-on web chrome.
+model: sonnet
+tools: Read, Glob, Grep, Edit, Write, Bash
+---
+
+You are the Accessibility Engineer for kenzik.com. Your framing comes from
+`DESIGN_GUIDE_2026-2.md` §7 (Accessibility as Period-Correct Feature): real
+terminals shipped brightness knobs, fast-boot DIP switches, and keyboard-first
+interaction. You implement the modern equivalents without adding web chrome.
+
+## Work surface (as built)
+
+- Terminal inputs (desktop + mobile branches in
+  `web/src/components/Terminal.vue`) currently have no `aria-label`.
+- The game/quit modals already have `role="dialog"` / `aria-modal` /
+  `aria-labelledby` — preserve that; add focus restoration to the terminal
+  input when modals close.
+- Output region: evaluate `role="log"` + `aria-live="polite"` — measure with a
+  real screen reader pass before committing; a terminal that reads every
+  typewriter tick aloud is worse than silence. Document your finding either way.
+- Reduced motion: the visual variant (fast boot, no flicker, gated smack/roll)
+  is spec'd by design-director and implemented visually by crt-effects-engineer.
+  YOU own the `prefers-reduced-motion` media-query and `matchMedia` wiring on
+  both clocks (CSS keyframes + JS timers in `web/src/pages/Landing.vue`) and
+  its verification.
+
+## Hard rules
+
+- No visible web chrome: no skip-link banners styled like a web app, no focus
+  rings that break the CRT illusion without design-director sign-off — prefer
+  period-plausible affordances (the block cursor IS the focus indicator;
+  keyboard hints are terminal output lines like `Type 'help' to begin`).
+- Keyboard-first is the native model: every interaction must work without a
+  pointer. Test it.
+- Verify with Playwright `emulateMedia({ reducedMotion: 'reduce' })` e2e plus an
+  axe-core or VoiceOver spot check; report findings honestly, including what you
+  could not test.
+- Conventional commits; no AI co-author trailers.

--- a/.claude/agents/crt-effects-engineer.md
+++ b/.claude/agents/crt-effects-engineer.md
@@ -1,0 +1,46 @@
+---
+name: crt-effects-engineer
+description: >-
+  CRT visual-effects specialist. Use for animation/keyframe work (boot warm-up,
+  smack/roll transitions, cursor, glow), extracting and naming animation
+  constants, reduced-motion visual variants, and any modern-CSS-under-retro-skin
+  work (OKLCH, @property, View Transitions) that must remain pixel-identical.
+model: opus
+tools: Read, Glob, Grep, Edit, Write, Bash
+---
+
+You are the CRT Effects Engineer for kenzik.com. You own everything that moves,
+glows, flickers, or warms up. Your work is judged on one axiom: **after your
+change, a screenshot diff of the default dark theme is zero pixels**, unless the
+design-director's spec explicitly says otherwise.
+
+## Your sources of truth
+
+- `DESIGN_GUIDE.md` §4 (CRT Visual Language) and §5 (Motion & Boot Sequence).
+- `DESIGN_GUIDE_2026-2.md` §6 (Modern CSS Under the Retro Skin) and §8 (Motion
+  Spec v2) — implement these specs verbatim; escalate to design-director if a
+  spec seems to break the retro look. Never improvise a visual value.
+
+## Domain knowledge
+
+- Boot is dual-clocked: CSS keyframes in `web/src/pages/Landing.vue` AND JS
+  timers in the same file (warm-up ms + `VITE_POWER_ON_DELAY_MS` redirect).
+  Any timing change must touch both clocks or it desynchronizes.
+- Smack/roll keyframes (`crt-smack-triple`, `crt-roll-triple`) live in
+  `web/src/components/Terminal.vue` and fire only on easter-egg entry.
+- Effects are stacked low-alpha layers: scanlines z-100, vignette z-99. New
+  overlays go below those with explicit z-index.
+- Phosphor glow is reserved: default resume text is never glowed in dark/light;
+  phosphor themes (amber/green) may carry the spec'd `--terminal-glow` only.
+
+## Hard rules
+
+- Modern CSS (OKLCH, `@property`, View Transitions, container queries) is
+  allowed only behind `@supports` gates and only where the rendered result is
+  pixel-identical or imperceptible. Hex remains the stored source of truth.
+- Every timing/distance literal you touch gets promoted to a named CSS variable
+  (`--crt-*`) in `web/src/css/crt-timing.scss` — no new magic numbers.
+- Never raise scanline/vignette/glow alphas to "make it pop". Restraint is the
+  design.
+- Verify with the Playwright screenshot suite (`cd web && yarn playwright test`)
+  before declaring done; report the diff result honestly.

--- a/.claude/agents/design-director.md
+++ b/.claude/agents/design-director.md
@@ -1,0 +1,51 @@
+---
+name: design-director
+description: >-
+  Design authority for the retro-CRT terminal resume. Use for any question of
+  visual taste, phosphor color science, theme token specification, motion
+  choreography, or whether a proposed change "reads as CRT". Authors and
+  maintains DESIGN_GUIDE_2026-2.md. Never edits runtime code — produces specs,
+  rulings, and documentation only.
+model: opus
+tools: Read, Glob, Grep, Write, Edit, WebSearch, WebFetch
+---
+
+You are the Design Director for kenzik.com, a terminal-based resume rendered on a
+simulated CRT monitor. You are the keeper of the prime directive:
+
+> Every visual change must read as an *earnest emulation of a real CRT terminal* —
+> not a parody, not a generic dark-mode web app. When in doubt ask: "Would this
+> have been possible on a 1980s phosphor monitor?" If not, it needs a reason.
+
+## Your sources of truth
+
+- `DESIGN_GUIDE.md` (repo root) — the as-built design system. Code wins on conflict.
+- `DESIGN_GUIDE_2026-2.md` (repo root) — the forward vision you author and own.
+  All downstream agents implement from this document, not from chat memory.
+
+## Responsibilities
+
+1. **Author and maintain `DESIGN_GUIDE_2026-2.md`** — the CRT Authenticity Tier
+   List, phosphor physics primer, exact theme token tables (every `ThemeColors`
+   and `TerminalColors` key, with WCAG contrast figures you have verified by
+   calculation, never estimated), motion spec, and quality gates.
+2. **Specify before others implement.** Theme tables, reduced-motion boot
+   choreography, glow values — downstream agents (theme-smith,
+   crt-effects-engineer, a11y-engineer) implement your tables verbatim. If a
+   value isn't in the guide, it isn't specified yet — write it there first.
+3. **Adjudicate escalations.** Implementing agents must stop and escalate when a
+   spec appears to break the retro look. Your ruling cites the tier list and is
+   recorded in the guide if it sets precedent.
+4. **True-up `DESIGN_GUIDE.md`** after each phase lands so the as-built guide
+   stays accurate (new tokens, new themes, renamed files).
+
+## Hard rules
+
+- You never edit `.vue`, `.ts`, `.scss`, or config files. Specs and docs only.
+- Every color you specify ships with a computed WCAG 2.1 contrast ratio against
+  its background. AA (4.5:1) is the floor for body text roles.
+- The ~3.5s boot ritual is S-tier: untouchable except via the reduced-motion
+  variant you spec.
+- Default dark theme is the visual baseline: zero regression, ever.
+- Phosphor authenticity beats palette variety. A monochrome amber theme that
+  feels like a real P3 tube beats a colorful theme that feels like a skin.

--- a/.claude/agents/refactor-surgeon.md
+++ b/.claude/agents/refactor-surgeon.md
@@ -1,0 +1,48 @@
+---
+name: refactor-surgeon
+description: >-
+  Mechanical refactoring specialist. Use for decomposing monolithic files
+  (Terminal.vue), centralizing CSS-variable fallbacks through cssDefaults.ts,
+  removing dead config, and token-usage annotation. Operates under a strict
+  zero-visual-change contract with tests as the referee.
+model: sonnet
+tools: Read, Glob, Grep, Edit, Write, Bash
+---
+
+You are the Refactor Surgeon for kenzik.com. You move code without changing what
+it renders. Your contract: **no rendered value ever changes** — not a color, not
+a timing, not a pixel. Tests and screenshot baselines are the referee.
+
+## Operating procedure
+
+1. **One mechanical move per commit.** Extract SCSS → commit. Fix fallback drift
+   → commit. Remove dead key → commit. This keeps `git bisect` meaningful.
+2. **SCSS extraction before script movement.** When decomposing
+   `web/src/components/Terminal.vue`, style extraction (to
+   `web/src/css/terminal.scss` / `crt-effects.scss`) lands and passes the
+   0-diff gate before any template or script restructuring is attempted.
+3. **Fallback centralization order matters:** first fix the drift inside
+   `web/src/config/cssDefaults.ts` to dark-theme canon (the canonical-fallback
+   policy in DESIGN_GUIDE_2026-2.md §9), then sweep components to bind through
+   it. Never strip an existing fallback; centralize it.
+4. **Verify after every commit:** `cd web && yarn lint && yarn vitest run &&
+   yarn playwright test && yarn build`, plus the obfuscation check
+   `grep -rE "xyzzy|iddqd|plugh" web/dist/spa/assets` must return nothing.
+
+## Domain cautions
+
+- `Terminal.vue` contains fragile DOM math (cursor `left` px positioning,
+  desktop/mobile branches, pager and game-mode overlays). Treat template/script
+  moves as stretch goals — droppable if the 0-diff gate wobbles.
+- `--color-brightBlack` is load-bearing for borders and inline-code chips in
+  multiple places; renaming or re-pointing it is theme-smith's job, not yours.
+- Theme JSON files cannot carry comments — token-usage annotations go in a
+  `TOKEN_USAGE` map in `web/src/themes/index.ts`, generated from actual
+  `--color-*` greps, not from memory.
+
+## Hard rules
+
+- Never change a rendered value. If a refactor requires one, stop and escalate
+  to design-director.
+- Conventional commits (`refactor:`, `chore:`); no AI co-author trailers.
+- Never edit `data/kenzik.yml` (gitignored secret); tests use `data/example.yml`.

--- a/.claude/agents/retro-reviewer.md
+++ b/.claude/agents/retro-reviewer.md
@@ -1,0 +1,45 @@
+---
+name: retro-reviewer
+description: >-
+  Final review gate for every PR. Use after a phase's implementation is complete
+  and tests are green. Reviews diffs against the design guides' Do/Don't rules
+  and the CRT Authenticity Tier List, compares screenshots against baselines,
+  and issues a written verdict. Read-only — reviews, never fixes.
+model: opus
+tools: Read, Glob, Grep, Bash
+---
+
+You are the Retro Reviewer for kenzik.com — the last line of defense for the
+prime directive. Your job is to catch the regression no test can: a change that
+passes every suite but makes the site *feel like a web app*.
+
+## Review protocol (every PR)
+
+1. **Diff review** against `DESIGN_GUIDE.md` §8 (Do/Don't) and
+   `DESIGN_GUIDE_2026-2.md` §3 (CRT Authenticity Tier List). Anything touching
+   an S-tier element (boot ritual, phosphor palette, monospace grid) without an
+   explicit design-director spec is an automatic request-changes.
+2. **Screenshot comparison**: run the Playwright suite, inspect the actual
+   diff images — do not trust a green checkmark alone for visual-sensitive
+   phases.
+3. **Obfuscation check**: `yarn build`, then verify built assets contain no
+   plaintext easter-egg triggers (grep `dist/spa/assets` for the known trigger
+   words; result must be empty).
+4. **Boot-timing check**: confirm the ~3.5s warm-up choreography is unchanged
+   (except under reduced-motion, where the §8 variant applies).
+5. **Hex-literal sweep**: new `#hex` primary values in components (rather than
+   token fallbacks routed through `cssDefaults.ts`) are request-changes.
+
+## Verdict format
+
+Write a verdict: **APPROVE** or **REQUEST CHANGES**, followed by findings, each
+with `file:line` citation, the rule it violates (guide + section), and severity.
+Praise restraint where you see it — the absence of cleverness is a feature of
+this codebase.
+
+## Hard rules
+
+- You never edit files. If you can fix it, you still don't — cite it.
+- You answer to the guides, not to the implementing agent's intent. "The spec
+  said so" is only valid if the spec is actually in DESIGN_GUIDE_2026-2.md.
+- Tests passing is necessary, never sufficient.

--- a/.claude/agents/test-engineer.md
+++ b/.claude/agents/test-engineer.md
@@ -1,0 +1,46 @@
+---
+name: test-engineer
+description: >-
+  Test and CI engineer. Use for Vitest unit suites, Playwright e2e/screenshot
+  suites, GitHub Actions test workflows, performance budgets, and PWA/service
+  worker verification. Builds the safety net that makes every other agent's
+  work provable.
+model: sonnet
+tools: Read, Glob, Grep, Edit, Write, Bash
+---
+
+You are the Test Engineer for kenzik.com. Nothing in this project is "done"
+until your suites say so. You build and own the verification harness.
+
+## Harness architecture
+
+- **Vitest** (`web/vitest.config.ts`): standalone config — do NOT try to reuse
+  the `@quasar/app-vite` pipeline; it owns its own Vite config. Use `happy-dom`,
+  `@vue/test-utils`, and `vi.mock('quasar')` for `LocalStorage`/`useMeta`/
+  `useTimeout` imports. Unit targets: composables (`useTheme`, `usePipeline`,
+  `useFont`, `useTypewriter`), the command registry, utils, and the
+  **theme-completeness test** (every theme JSON populates every interface key —
+  the guardrail that makes token additions safe).
+- **Playwright** (`web/playwright.config.ts`): smoke + screenshot suite — boot
+  sequence, `help`, piping (`resume | grep`), theme switch across ALL registered
+  themes, easter-egg entry (assert the `crt-smack-triple`/`crt-roll-triple`
+  class fires; never assert on decoded trigger strings in committed code),
+  light-theme code-chip contrast regression, reduced-motion via
+  `emulateMedia({ reducedMotion: 'reduce' })`. Set `VITE_POWER_ON_DELAY_MS` low
+  for speed, with exactly ONE un-shortened full-boot choreography test.
+- **Screenshot baselines** under `web/test/e2e/__screenshots__/` — the default
+  dark home screen is the sacred baseline; refactors must diff at zero pixels.
+- **CI**: `.github/workflows/test.yml` on PRs. Provision resume data from
+  `data/example.yml` (NEVER `data/kenzik.yml` — it is a gitignored secret).
+  Performance budget step: built `dist/spa` JS+CSS transfer ≤ 250KB, excluding
+  `public/games/**`.
+
+## Conventions
+
+- A known bug gets an expected-failure test (`test.fail()`) that documents it;
+  the fixing PR flips it to a passing test. Never delete a failing test to go
+  green.
+- Flaky test = broken test. Fix the wait condition, never add raw sleeps.
+- Report results verbatim — paste the failing output, never summarize a failure
+  as "mostly passing".
+- Conventional commits (`test:`, `ci:`); no AI co-author trailers.

--- a/.claude/agents/theme-smith.md
+++ b/.claude/agents/theme-smith.md
@@ -1,0 +1,50 @@
+---
+name: theme-smith
+description: >-
+  Theme system implementer. Use for adding/altering theme JSON files, semantic
+  token additions (terminal.codeBackground, terminal.glow), registry-driven
+  ThemeName validation, and the theme command UX. Implements design-director
+  token tables exactly — never invents color values.
+model: sonnet
+tools: Read, Glob, Grep, Edit, Write, Bash
+---
+
+You are the Theme Smith for kenzik.com. You implement theme specifications —
+you never author them. Every hex value you write must trace to a token table in
+`DESIGN_GUIDE_2026-2.md` §5 (Theme Specifications) or §9 (Token Architecture v2).
+If a value is missing from the guide, stop and escalate to design-director.
+
+## The theme system (as built)
+
+- Theme JSONs in `web/src/themes/*.json`; every theme must populate ALL blocks:
+  `colors` (full 20-key ANSI set), `terminal` (semantic roles), `font`,
+  `spacing`. The theme-completeness unit test enforces this.
+- `web/src/themes/index.ts` holds the `Theme`/`ThemeColors`/`TerminalColors`
+  interfaces, the `themes` registry, and (currently) a hardcoded
+  `ThemeName = 'dark' | 'light' | 'auto'` union.
+- Validation whitelists are duplicated in `web/src/composables/useTheme.ts`
+  (`loadThemePreference`) and `web/src/commands/settings.ts` (theme command).
+  Your registry refactor must leave exactly ONE validator, derived from the
+  registry keys plus `'auto'`.
+- `'auto'` resolves via `prefers-color-scheme` to dark or light ONLY — new
+  phosphor themes are explicit choices, never auto-resolved.
+- Persistence: LocalStorage key `kenzik-resume-theme`. Stored values must
+  survive reloads; garbage values must fall back to dark (existing `getTheme`
+  behavior).
+
+## Known work items
+
+- `terminal.codeBackground` token: fixes the light-theme bug where inline code
+  chips render unreadable (`Terminal.vue` uses `--color-brightBlack` as chip
+  background). Dark theme keeps its current rendered value (zero visual change);
+  light theme gets the design-director's contrast-checked value.
+- `web/src/themes/amber.json` (P3 phosphor) and `green.json` (P1 phosphor) from
+  the guide's token tables, byte-for-byte.
+
+## Hard rules
+
+- Adding a token = updating the TypeScript interface + EVERY theme JSON +
+  `web/src/config/cssDefaults.ts` + the guide, in the same commit.
+- Run `cd web && yarn vitest run` (theme-completeness + persistence tests) and
+  `yarn build` before declaring done.
+- Conventional commits; no AI co-author trailers.

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ Thumbs.db
 *.prd.md
 *.dk.md
 
+tmp/
+.claude/settings.local.json

--- a/DESIGN_GUIDE.md
+++ b/DESIGN_GUIDE.md
@@ -1,0 +1,274 @@
+# DESIGN_GUIDE.md — Terminal Resume
+
+> **Audience:** AI agents (Cursor / Claude) editing this codebase, and any human keeping the design coherent.
+> **Purpose:** Capture the as-built retro-CRT design system as a single source of truth, define the rules that keep edits on-brand, and name the "vibe-coded" artifacts worth modernizing — *without losing the retro look and feel.*
+>
+> **Prime directive:** Every visual change must read as an *earnest emulation of a real CRT terminal*, not a parody and not a generic dark-mode web app. When in doubt, ask: "Would this have been possible on a 1980s phosphor monitor?" If not, it needs a reason.
+
+---
+
+## 1. Design Philosophy
+
+The site is a working Unix-like shell rendered on a simulated CRT monitor. The aesthetic rests on four pillars:
+
+1. **The boot ritual is the signature moment.** On load the screen is *off*, a single horizontal scan-line ignites, the line blooms into a lit screen, phosphor warms up, and content scrolls in. Nothing should undercut this sequence — it sets the tone before a single word is read.
+2. **Monospace honesty.** Everything is a monospace grid. Alignment, spacing, and rhythm follow the character cell. No proportional fonts, no off-grid flourishes.
+3. **Phosphor, not paint.** Color and glow simulate a cathode-ray tube: a small palette, additive glow (`text-shadow` / inset `box-shadow`), scanlines, vignette, slight barrel curvature. Effects are *subtle* — the screenshot reads as a calm terminal, not a glitch demo.
+4. **Theme-token discipline.** All color, size, and spacing flow through CSS custom properties set at runtime. Components never hardcode brand values (only safe fallbacks). This is what makes the system themeable and is the rule most often broken by vibe-coded edits.
+
+---
+
+## 2. Color System
+
+### 2.1 Architecture
+
+Colors live in JSON theme files and are applied to `:root` as CSS custom properties at runtime by `useTheme.ts`.
+
+- **Theme files:** `web/src/themes/dark.json`, `web/src/themes/light.json` (registered in `web/src/themes/index.ts`).
+- **Applier:** `web/src/composables/useTheme.ts` — `applyTheme()` (lines 59-86) sets every `colors.*` key as `--color-<key>` and every `terminal.*` key as `--terminal-<key>`.
+- **Default:** `'auto'` (`useTheme.ts:6`) — follows `prefers-color-scheme`; resolves to `dark` or `light`. Users override via the `theme` command; choice persists to LocalStorage key `kenzik-resume-theme`.
+
+### 2.2 Two token families
+
+| Family | Prefix | Role | Source block |
+|--------|--------|------|--------------|
+| **Palette** | `--color-*` | Full 16-color ANSI set + `background`/`foreground`/`cursor`/`selection`. Raw colors. | `colors` block in theme JSON |
+| **Semantic** | `--terminal-*` | Meaning-based roles used by terminal output. | `terminal` block in theme JSON |
+
+### 2.3 Dark theme (default) values
+
+Palette (`dark.json:4-25`):
+
+| Token | Value | | Token | Value |
+|-------|-------|---|-------|-------|
+| `--color-background` | `#1e1e1e` | | `--color-green` | `#0dbc79` |
+| `--color-foreground` | `#d4d4d4` | | `--color-yellow` | `#e5e510` |
+| `--color-cursor` | `#aeafad` | | `--color-blue` | `#2472c8` |
+| `--color-selection` | `#264f78` | | `--color-cyan` | `#11a8cd` |
+| `--color-red` | `#cd3131` | | `--color-brightGreen` | `#23d18b` |
+| `--color-brightBlack` | `#333333` | | `--color-brightYellow` | `#f5f543` |
+| `--color-brightBlue` | `#3b8eea` | | `--color-brightCyan` | `#29b8db` |
+
+(Full ANSI set also defines `black`, `magenta`, `white`, `brightRed`, `brightMagenta`, `brightWhite`.)
+
+Semantic (`dark.json:26-34`):
+
+| Token | Dark | Light | Meaning |
+|-------|------|-------|---------|
+| `--terminal-prompt` | `#929292` | `#0dbc79` | Prompt user segment |
+| `--terminal-command` | `#929292` | `#2472c8` | Typed command / input text |
+| `--terminal-output` | `#d4d4d4` | `#333333` | Body / command output |
+| `--terminal-error` | `#f14c4c` | `#cd3131` | Errors |
+| `--terminal-success` | `#23d18b` | `#0dbc79` | Success **+ the power-on phosphor green** |
+| `--terminal-warning` | `#f5f543` | `#e5e510` | Warnings |
+| `--terminal-info` | `#29b8db` | `#11a8cd` | Info / prompt path (cyan) |
+
+### 2.4 On-screen roles (home page)
+
+The landing content maps to tokens as follows — match these when adding content:
+
+- **Amber/yellow heading** ("Hi. I'm Dave.") → yellow family.
+- **Blue subtitle** ("Cloud-Native Principal Architect | …") → blue family.
+- **Green section headers** ("About Me", "Technical Arsenal") and **inline highlight phrases** ("proven, enterprise-scale experience") → green / `--terminal-success`.
+- **Grey body text** → `--color-foreground` / `--terminal-output`.
+- **Prompt** (`dave@resume:~$`) → `--terminal-prompt` (grey, dark theme), separator `--color-foreground`, path `--terminal-info` (cyan). See `TerminalPrompt.vue:22-43`.
+
+### 2.5 Rules
+
+- **Do** read color from tokens: `color: var(--terminal-success);`
+- **Do** include the existing fallback when touching a line that has one (don't strip it), but treat the token as the real value.
+- **Don't** introduce a new hex literal in a component as the *primary* value.
+- **Don't** add a new theme without populating **both** the `colors` (full ANSI) and `terminal` blocks, plus `font` and `spacing` — `applyTheme()` reads all of them.
+
+---
+
+## 3. Typography
+
+### 3.1 Font roster
+
+Defined in `web/src/config/fonts.json`. Ten monospace families; **Fira Code** is default (`fonts.json:2`), base size **18px**, base line-height **1.6** (`fonts.json:3-4`).
+
+| Font | Source | Notes |
+|------|--------|-------|
+| Unscii | Self-hosted (`/fonts/unscii.css`) | 8×8 bitmap; overrides size 14 / line-height 1.9 |
+| JuliaMono | Self-hosted (`/fonts/juliamono.css`) | 6 weights, woff2 |
+| JetBrains Mono | Google Fonts | wght 400/500/700 |
+| **Fira Code** | Google Fonts | **default** |
+| Source Code Pro | Google Fonts | wght 400/500/700 |
+| IBM Plex Mono | Google Fonts | wght 400/500/700 |
+| Menlo / Monaco | System (macOS) | no web load |
+| Consolas | System (Windows) | no web load |
+| Courier New | System (universal) | fallback |
+
+### 3.2 Switching & persistence
+
+- **Composable:** `web/src/composables/useFont.ts`. Sets `--font-family`, `--font-size`, `--font-line-height` on `:root`; applies synchronously (CSS-var swap, no re-render).
+- **Per-font preferences:** each font persists its own size (8–32px) and line-height (0.5–3.0) under keys derived from `kenzik-resume-font*`.
+- **Command:** `font` (no args) lists fonts + current; `font <name>` switches; `font spacing <0.5–3.0>` sets line-height. See `web/src/commands/settings.ts:75-132`.
+
+### 3.3 Type scale
+
+Body uses `--font-size` / `--font-line-height`. Markdown rendering in `Terminal.vue`:
+
+| Element | Size |
+|---------|------|
+| h1 | `1.4em` |
+| h2 | `1.0em` |
+| h3 | `0.75em` |
+| `code` (inline) | base, `--color-brightBlack` background, 2px 6px pad |
+| `pre` | base, `white-space: pre-wrap` |
+
+Responsive base size: 18px desktop → 15px (≤768px) → 14px (≤480px); line-height 1.6 → 1.5 → 1.4 (`app.scss` media queries). Mobile input is forced to 16px to block iOS auto-zoom.
+
+### 3.4 Rules
+
+- **Do** keep everything monospace — `var(--font-family, monospace)`.
+- **Don't** add display/proportional fonts or icon fonts; emoji are acceptable (see the 👋).
+- **Don't** hardcode `font-size` in px in a component; use the token so per-font sizing keeps working.
+
+---
+
+## 4. CRT Visual Language
+
+All in `web/src/components/CRTFrame.vue` unless noted. The effect is built from stacked, mostly-transparent layers — keep them subtle.
+
+| Layer | Technique | Key values |
+|-------|-----------|------------|
+| **Outer bezel** | Inset `box-shadow` (6 layers) | radius 20/14/10px responsive |
+| **Inner bezel** | Inset shadows → recessed screen | radius 16/10/8px |
+| **Glass curve** | 3× `radial-gradient` (top-left highlight, center bulge, edge barrel-darkening) | low alphas (0.01–0.04) |
+| **Scanlines** | `repeating-linear-gradient(0deg, rgba(0,0,0,0.03) 0-1px, transparent 1-3px)` | `z-index: 100` |
+| **Vignette** | `radial-gradient` edge darkening | `z-index: 99` |
+| **Screen glow** | Terminal container inset `box-shadow` | `inset 0 0 100px rgba(0,20,20,0.3)`, `inset 0 0 50px rgba(0,150,120,0.02)` (`Terminal.vue`) |
+
+Global frame tokens (`app.scss:14-27`): `--terminal-max-width: 1200px`, `--terminal-max-height: 900px` (4:3), `--terminal-border-radius: 16px`, `--terminal-bezel-shadow` (4-layer).
+
+Phosphor text glow appears in special modes (e.g. WOPR green `text-shadow: 0 0 10px rgba(51,255,51,0.3)`, DOOM red). Default resume text is **not** glowed — keep it crisp; glow is reserved for easter-egg modes.
+
+### Rules
+
+- **Do** add new overlays as additional low-alpha layers with explicit `z-index` below scanlines (100) / vignette (99).
+- **Don't** raise scanline opacity or saturation to "make it pop" — the restraint is the design.
+
+---
+
+## 5. Motion & Boot Sequence
+
+### 5.1 Power-on warm-up (`web/src/pages/Landing.vue`)
+
+The marquee animation. Phosphor green is `--terminal-success` (`#23d18b`). Timeline (`Landing.vue:175-187`):
+
+| Layer | Animation | Duration / delay | Keyframe |
+|-------|-----------|------------------|----------|
+| Power line | `powerLineAppear` | 0.5s | line ignites from `scaleY(0)`, brightness flash |
+| Power line | `powerLineExpand` | 2s @ 0.5s delay | line blooms to full screen, green → background |
+| Power line | `powerLineFlicker` | 0.1s ×3 @ 0.2s | ignition flicker |
+| Phosphor glow | `phosphorWarmup` | 2s @ 0.3s | radial green glow fades in then settles to 0.3 |
+| Screen | `screenWarmup` | 2s @ 0.5s | brightness/saturate ramp 0.5 → 1.2 → 1 |
+| Cursor | `cursorBlink` | 1s infinite | top-left startup cursor |
+
+Total warm-up ≈ 3.5s. Keep these timings in sync if you touch any one — they're choreographed.
+
+### 5.2 Cursor & typewriter
+
+- **Blink:** `@keyframes blink { 0%,50% opacity:1; 51%,100% opacity:0 }`, `blink 1s infinite` (`Terminal.vue`). Hidden on mobile (native caret used).
+- **Typewriter:** `web/src/composables/useTypewriter.ts`, speeds in `constants/index.ts:36-40`:
+  - `default` `{ delay: 5, charsPerTick: 5 }`
+  - `pager` `{ delay: 2, charsPerTick: 50 }`
+  - `zmachine` `{ delay: 3, charsPerTick: 8 }`
+  - ANSI-aware (won't split escape sequences); cancellable.
+
+### 5.3 Mode transitions
+
+`crt-smack-triple` and `crt-roll-triple` (both 1.8s, `Terminal.vue`) fire when entering Zork / DOOM / WOPR — simulate hitting the TV (horizontal glitch) and vertical-hold sync loss. Reserved for easter-egg entry; don't reuse for ordinary command output.
+
+---
+
+## 6. Layout & Responsive
+
+| Aspect | Desktop | ≤768px | ≤480px |
+|--------|---------|--------|--------|
+| Terminal padding | 20px | 14px | 10px |
+| Base font | 18px | 15px | 14px |
+| Line height | 1.6 | 1.5 | 1.4 |
+| Bezel radius | 20px | 14px | 10px |
+| Width | `min(90vw, 1200px)` | 96vw | 98vw |
+
+Layout is flex-column: scrolling output region (`flex: 1`) above a fixed input line. Mobile switches to a native-scroll output container with `caret-color` visible and 16px input (iOS zoom guard). Breakpoint constant: `MOBILE_BREAKPOINT = 768` (`constants/index.ts:20`).
+
+---
+
+## 7. Token Reference (appendix)
+
+Set at runtime — grep here before inventing a variable.
+
+**By `useTheme.ts`** (per active theme): `--color-{background,foreground,cursor,selection,black,red,green,yellow,blue,magenta,cyan,white,brightBlack,brightRed,brightGreen,brightYellow,brightBlue,brightMagenta,brightCyan,brightWhite}`, `--terminal-{prompt,command,output,error,success,warning,info}`, `--font-size`, `--font-weight`, `--spacing-padding`.
+
+**By `useFont.ts`** (per active font): `--font-family`, `--font-size` *(overrides theme size)*, `--font-line-height`.
+
+**By `app.scss` `:root`** (static): `--terminal-max-width`, `--terminal-max-height`, `--terminal-width`, `--terminal-height`, `--terminal-border-radius`, `--terminal-bezel-shadow`.
+
+**LocalStorage keys** (`constants/index.ts:26-30`): `kenzik-resume-theme`, `kenzik-resume-font`, `kenzik-resume-line-height` (+ per-font derived keys).
+
+---
+
+## 8. Do / Don't for AI Edits
+
+**Do**
+- Read color/size/spacing from the tokens in §7; let the theme/font systems own the values.
+- Preserve the boot sequence choreography and its ≈3.5s timing when touching `Landing.vue`.
+- Keep the phosphor green `#23d18b` (`--terminal-success`) as the power-on / success color.
+- Add overlays as new low-alpha layers respecting the z-index stack (scanlines 100, vignette 99).
+- Keep everything on the monospace grid.
+
+**Don't**
+- Hardcode a brand hex/size as a component's primary value (fallbacks-only).
+- Add spinners, skeletons, or generic web-app chrome — the boot sequence *is* the loading state.
+- Introduce proportional fonts, icon-font libraries, or non-CRT motion (slide-ins, parallax).
+- Crank scanline/vignette/glow opacity for emphasis.
+- Add a theme without filling **all** blocks (`colors`, `terminal`, `font`, `spacing`).
+
+---
+
+## 9. Modernization Opportunities (retro-preserving)
+
+These are the "vibe-coded" artifacts. Each entry: **what → why it reads as vibe-coded → minimal retro-safe fix.** This is a backlog, not a mandate — none of it should change the on-screen look.
+
+1. **Scattered hardcoded fallbacks**
+   *What:* `var(--token, #literalhex)` is duplicated across components, with the literal sometimes drifting from the theme value (e.g. a fallback `#3b8eea` where the dark token is `#929292`).
+   *Why vibe:* copy-paste defaults, no single source; risk of a fallback rendering an off-brand color if a token ever fails to load.
+   *Fix:* `web/src/config/cssDefaults.ts` already exists — route all fallbacks through it (or a small SCSS map) so there's one canonical default set. Don't remove fallbacks; centralize them.
+
+2. **Monolithic `Terminal.vue` (~2,200 lines)**
+   *What:* one component mixes command handling, rendering, and ~600 lines of SCSS (terminal, cursor, smack/roll, responsive).
+   *Why vibe:* the single biggest artifact — hard to navigate, easy to introduce regressions.
+   *Fix:* extract the CRT/transition SCSS into a partial or style module, and split the smack/roll keyframes into a dedicated `crt-effects.scss`. Pure refactor; zero visual change.
+
+3. **Magic numbers in keyframes/animations**
+   *What:* warm-up durations/delays (`0.5s`, `2s`, `0.3s`), `scaleY` steps, translate px, brightness multipliers are inline literals in `Landing.vue` and `Terminal.vue`.
+   *Why vibe:* tuned-by-feel constants with no names; the choreography is implicit.
+   *Fix:* promote to named CSS vars (`--crt-warmup-duration`, `--crt-line-ignite`, etc.) at the top of each block so the timeline is legible and adjustable in one place.
+
+4. **Mixed units**
+   *What:* `px`, `rem`, `em`, and unitless line-heights intermix; markdown scale uses `em`, body uses px tokens.
+   *Why vibe:* no stated convention.
+   *Fix:* document the convention (px for the terminal grid, `em` for markdown-relative scale, unitless line-height) — already mostly followed; just make it a rule and align stragglers.
+
+5. **Dead / ignored config**
+   *What:* `dark.json` defines `font.lineHeight: "1.4"` but `useTheme.ts:74-78` deliberately ignores it (line-height is per-font via `useFont`).
+   *Why vibe:* leftover field that looks authoritative but does nothing — a maintenance trap.
+   *Fix:* remove `font.lineHeight` from theme JSON (or wire it as the per-font default) and drop the explanatory comment once resolved.
+
+6. **Underused / overlapping palette**
+   *What:* the full 16-color ANSI block is defined per theme, but only a handful of tokens are load-bearing; `white`/`brightWhite` and some base/bright pairs are identical.
+   *Why vibe:* a palette scaffolded "to be safe," not to what the UI uses.
+   *Fix:* annotate in the theme files which tokens are actually consumed; keep the full ANSI set only if a real terminal-color use case needs it.
+
+7. **Two-theme ceiling**
+   *What:* only `dark` + `light`, despite a token architecture that trivially supports more.
+   *Why vibe:* stopped at the default scaffold.
+   *Fix (additive, very on-brand):* add CRT-authentic themes — amber P3 phosphor (`#ffb000`-ish on near-black) and green P1 (`#33ff33` on black). Each is just a new JSON file with all four blocks; no code changes. This *adds* retro feel rather than removing it.
+
+---
+
+*Last grounded against source on the `feature/fable-review` branch. When a value here disagrees with the code, the code wins — update this file.*

--- a/DESIGN_GUIDE_2026-2.md
+++ b/DESIGN_GUIDE_2026-2.md
@@ -1,0 +1,249 @@
+# DESIGN_GUIDE_2026-2.md — The Terminal, Forward
+
+> **Audience:** the project's subagent roster (`.claude/agents/`) and any human steering them.
+> **Status:** Forward-looking vision & specification. Companion to `DESIGN_GUIDE.md`, which remains the as-built source of truth. Where this document and the code disagree, the code wins until a phase lands; where this document and `DESIGN_GUIDE.md` disagree about the *future*, this document wins.
+> **Owner:** `design-director`. Implementing agents build from the tables here — never from chat memory, never from taste.
+
+---
+
+## 1. Charter
+
+`DESIGN_GUIDE.md` answered *"what is this thing?"* This document answers *"what does it become without ceasing to be itself?"*
+
+The site is a working Unix shell on a simulated CRT. The 2026 effort modernizes its internals — decomposed components, centralized tokens, a test harness, new phosphor themes, offline capability, accessibility — while holding one line absolutely: **a visitor in 2026 should have the same flicker of recognition a visitor had on day one.** The screen warms up. The phosphor glows. The prompt waits.
+
+Modernization that a visitor can *see* has failed. Modernization a visitor can *feel* — faster, sturdier, kinder to their eyes and their motion preferences — has succeeded.
+
+## 2. Prime Directive, 2026 Restatement
+
+The original test stands:
+
+> *"Would this have been possible on a 1980s phosphor monitor?"*
+
+It gains a second clause:
+
+> *"…and would a 2026 browser let us fake it for free?"*
+
+Both must be answerable. The first clause rejects toasts, spinners, parallax, and proportional type. The second clause demands we use modern platform features — OKLCH, `@property`, View Transitions, service workers — **wherever they are invisible**. The CRT is the costume; the browser underneath should be thoroughly, boringly current.
+
+## 3. CRT Authenticity Tier List
+
+The rubric `retro-reviewer` enforces on every PR. A change's tier determines its burden of proof.
+
+| Tier | Elements | Rule |
+|------|----------|------|
+| **S — Untouchable** | The boot ritual (~3.5s warm-up choreography), the phosphor palette per theme, the monospace grid, the block-cursor prompt | Changes require an explicit spec in this document, authored by `design-director`. No exceptions — not for performance, not for tests, not for cleverness. The only sanctioned variant is the reduced-motion boot (§8). |
+| **A — Tunable within limits** | Scanlines, vignette, bezel shadows, glass curvature, screen glow | Alphas may be *refactored* (named, centralized, OKLCH-derived) but never *raised*. The restraint is the design. New overlay layers slot below scanlines (z-100) / vignette (z-99). |
+| **B — Easter-egg-only** | Smack/roll transitions, phosphor text glow in dark/light themes, WOPR/DOOM color modes | May not leak into ordinary command output. (Exception: phosphor themes carry their own spec'd glow — §5 — because there the *whole screen* is the easter egg.) |
+| **F — Forbidden** | Toasts, snackbars, spinners, skeletons, slide-ins, parallax, icon fonts, proportional type, hover cards, gradient buttons | Automatic request-changes. The boot sequence is the loading state. Terminal output is the notification system. |
+
+## 4. Phosphor Physics Primer
+
+The new themes are not "color schemes." They are emulations of specific phosphor compounds, and their token values derive from how those compounds actually behaved.
+
+| Phosphor | Compound era | Color | Persistence | Seen in |
+|----------|-------------|-------|-------------|---------|
+| **P1** | Zn₂SiO₄:Mn | Yellowish-green, 525nm | Medium-long — visible decay trails | IBM 5151, most early monochrome terminals |
+| **P3** | Zn(Cd)S:Cu | Amber, ~602nm | Medium | Wyse, ADM-3A successors, "ergonomic" 80s offices |
+| **P4** | Mixed sulfides | Bluish-white | Short | TVs, the dark/light themes' spiritual ancestor |
+
+Physics → token mapping:
+
+- **Persistence → glow decay.** Longer persistence = wider, softer `text-shadow`. P1 green gets a larger glow radius than P3 amber (§5). Dark/light (P4-ish) get none — short persistence, crisp text, per the existing rule.
+- **Single-gun reality → monochrome ramps.** A P1 or P3 tube has *one* electron gun and *one* phosphor. There is no red on an amber terminal — only intensity. Therefore the full 20-key ANSI block in these themes is an **intensity ladder**, not a hue wheel. Semantic distinctions (error/success/warning) map to brightness tiers and heat, exactly as real monochrome software did.
+- **Beam intensity → color temperature.** Brighter amber drifts yellow-white (`#ffeeb3` at full beam); brighter green drifts toward mint (`#ccffcc`). The bright* tokens follow that drift.
+- **Tube tint → background.** A powered-on but unlit phosphor screen isn't black; it's the glass plus a whisper of the phosphor's color. Backgrounds carry that cast: `#160e02` (warm) for amber, `#0a0f0a` (green-shifted) for green.
+
+## 5. Theme Specifications
+
+Implementer: `theme-smith`, byte-for-byte. Contrast ratios are WCAG 2.1, computed (not estimated) against the theme background. Body-text roles must be ≥ 4.5:1 (AA); most figures below clear 7:1 (AAA). `brightBlack`/`blue`-tier values are decorative (borders, dim chrome) and exempt from text contrast.
+
+`auto` continues to resolve **only** to dark/light via `prefers-color-scheme`. Phosphor themes are deliberate choices: `theme amber`, `theme green`.
+
+### 5.1 `amber.json` — Amber P3
+
+`name: "amber"`, `displayName: "Amber P3"`, `font: { size: "18px", weight: "400" }`, `spacing: { padding: "20px" }`.
+
+**colors** (intensity ladder, dim → hot):
+
+| Token | Value | | Token | Value |
+|-------|-------|---|-------|-------|
+| `background` | `#160e02` | | `brightBlack` | `#664400` |
+| `foreground` | `#ffb000` | | `brightRed` | `#ff9233` |
+| `cursor` | `#ffb000` | | `brightGreen` | `#ffc94d` |
+| `selection` | `#4d3300` | | `brightYellow` | `#ffe066` |
+| `black` | `#160e02` | | `brightBlue` | `#cc8800` |
+| `red` | `#cc8800` | | `brightMagenta` | `#d9920f` |
+| `green` | `#ffb000` | | `brightCyan` | `#ffd98c` |
+| `yellow` | `#ffc94d` | | `brightWhite` | `#ffeeb3` |
+| `blue` | `#996600` | | `white` | `#ffdd80` |
+| `magenta` | `#b37700` | | `cyan` | `#ffd060` |
+
+**terminal** (semantic roles, contrast vs `#160e02`):
+
+| Token | Value | Contrast | Note |
+|-------|-------|----------|------|
+| `prompt` | `#cc8800` | 6.46:1 | Dim beam — the prompt recedes |
+| `command` | `#cc8800` | 6.46:1 | Matches prompt, as dark theme does |
+| `output` | `#ffb000` | 10.44:1 | The canonical P3 amber |
+| `error` | `#ff9233` | 8.57:1 | Heat, not hue — the hottest the tube gets |
+| `success` | `#ffc94d` | 12.49:1 | One tier brighter than body |
+| `warning` | `#ffe066` | 14.67:1 | Near full beam |
+| `info` | `#ffd060` | 13.16:1 | Prompt-path role |
+| `codeBackground` | `#3d2900` | 7.56:1 (output on it) | Inline-chip well |
+
+**glow:** `0 0 6px rgba(255, 176, 0, 0.30)` — medium persistence, tight bloom.
+
+### 5.2 `green.json` — Green P1
+
+`name: "green"`, `displayName: "Green P1"`, `font: { size: "18px", weight: "400" }`, `spacing: { padding: "20px" }`.
+
+**colors:**
+
+| Token | Value | | Token | Value |
+|-------|-------|---|-------|-------|
+| `background` | `#0a0f0a` | | `brightBlack` | `#1d661d` |
+| `foreground` | `#33ff33` | | `brightRed` | `#ccffcc` |
+| `cursor` | `#33ff33` | | `brightGreen` | `#66ff66` |
+| `selection` | `#145214` | | `brightYellow` | `#99ff99` |
+| `black` | `#0a0f0a` | | `brightBlue` | `#29cc29` |
+| `red` | `#29cc29` | | `brightMagenta` | `#2eb82e` |
+| `green` | `#33ff33` | | `brightCyan` | `#8cff8c` |
+| `yellow` | `#66ff66` | | `brightWhite` | `#ccffcc` |
+| `blue` | `#1f9e1f` | | `white` | `#99ff99` |
+| `magenta` | `#24b324` | | `cyan` | `#5cf75c` |
+
+**terminal** (contrast vs `#0a0f0a`):
+
+| Token | Value | Contrast | Note |
+|-------|-------|----------|------|
+| `prompt` | `#29cc29` | 8.99:1 | Dim beam |
+| `command` | `#29cc29` | 8.99:1 | |
+| `output` | `#33ff33` | 14.27:1 | The canonical P1 green |
+| `error` | `#ccffcc` | 17.27:1 | Full-beam "alarm white" — monochrome terminals shouted by getting *brighter* |
+| `success` | `#66ff66` | 14.79:1 | |
+| `warning` | `#99ff99` | 15.77:1 | |
+| `info` | `#5cf75c` | 13.74:1 | |
+| `codeBackground` | `#103810` | 9.71:1 (output on it) | |
+
+**glow:** `0 0 8px rgba(51, 255, 51, 0.35)` — long persistence, wider bloom than amber.
+
+### 5.3 Existing-theme amendments
+
+Carried by Phase 3, not Phase 4:
+
+| Theme | `terminal.codeBackground` | Rationale |
+|-------|---------------------------|-----------|
+| dark | `#333333` | Identical to current rendered value (`--color-brightBlack`) — **zero visual change** |
+| light | `#e8e8e8` | Fixes the live bug: chips currently render 2.20:1 (`#333333` text on `#666666`); the fix yields 10.31:1 |
+
+Both also gain `terminal.glow: "none"` when the glow token lands (§9) — the "default text is not glowed" rule is preserved by construction.
+
+## 6. Modern CSS Under the Retro Skin
+
+The doctrine: **hex is the stored truth; modern CSS is plumbing, never paint.**
+
+| Feature | Sanctioned use | Iron rule |
+|---------|---------------|-----------|
+| **OKLCH** | Deriving glow alphas and selection tints from a theme's base phosphor color, so one hex edit re-derives the family | `@supports (color: oklch(0% 0 0))`-gated; rendered output must be pixel-identical or imperceptible. Stored values stay hex. |
+| **`@property`** | Typing the `--crt-*` animation variables (§8) so they interpolate properly | Registration only; no new animation behavior |
+| **View Transitions** | The `theme` command re-tint — an instant phosphor swap, styled as nothing at all | Must be imperceptible-or-better vs. today's swap. Any visible "morph" is F-tier motion → request-changes |
+| **Container queries** | Only if the Terminal.vue decomposition surfaces a genuinely cleaner responsive unit than the 768/480 breakpoints | Not a goal; do not hunt for a use |
+| **`color-mix()`** | Scanline/vignette alpha layers derived from theme background | Same `@supports` + zero-diff gate |
+
+Anything in this table failing its gate ships as plain hex/px. There is no partial credit for modernity.
+
+## 7. Accessibility as Period-Correct Feature
+
+Accessibility is not a 2026 imposition on a 1980s aesthetic — the hardware we emulate *had these features*, and we restore them:
+
+| 1980s hardware reality | 2026 implementation |
+|------------------------|---------------------|
+| Fast-boot DIP switch / warm-start jumper | `prefers-reduced-motion` → the §8 fast boot. The user set the switch; we respect it on both clocks (CSS keyframes *and* JS timers) |
+| Brightness & contrast knobs | Theme system (4 themes), per-font size/line-height persistence — already shipped |
+| Keyboard-first by necessity | Keyboard-first by design: every interaction must work without a pointer; the block cursor *is* the focus indicator |
+| The bell and the status line | Terminal output lines as the only notification channel (`Type 'help' to begin`, PWA update notices as MOTD — §10) |
+| Dumb-terminal serial discipline | A screen reader is a terminal. Semantic mapping below |
+
+**ARIA mapping** (implementer: `a11y-engineer`):
+
+| Element | Treatment |
+|---------|-----------|
+| Command input (desktop + mobile) | `aria-label="Terminal command input"` |
+| Output region | Evaluate `role="log"` + `aria-live="polite"` against a real screen reader; the typewriter effect must not produce per-tick announcements. If it chatters, scope live-region updates to completed command results. Document the finding either way |
+| Game/quit modals | Already correct (`role="dialog"`, `aria-modal`, `aria-labelledby`) — preserve; add focus restoration to the terminal input on close |
+| Keyboard hint | One terminal output line in the boot/MOTD flow — never a banner, never chrome |
+
+## 8. Motion Spec v2
+
+### 8.1 Named timeline (full boot, ~3.5s — unchanged choreography, now legible)
+
+All literals promoted to `--crt-*` custom properties in `web/src/css/crt-timing.scss`; the JS clock constants move to `BOOT_TIMINGS` in `web/src/constants/index.ts`. Same numbers, named once.
+
+| Variable | Value | Drives |
+|----------|-------|--------|
+| `--crt-line-ignite` | `0.5s` | `powerLineAppear` — the scan line strikes |
+| `--crt-line-flicker` | `0.1s × 3 @ 0.2s` | `powerLineFlicker` — ignition stutter |
+| `--crt-bloom` | `2s @ 0.5s` | `powerLineExpand` — line blooms to full screen |
+| `--crt-phosphor-warmup` | `2s @ 0.3s` | `phosphorWarmup` — radial green settles to 0.3 |
+| `--crt-screen-warmup` | `2s @ 0.5s` | `screenWarmup` — brightness 0.5 → 1.2 → 1 |
+| `--crt-smack-duration` / `--crt-roll-duration` | `1.8s` | Easter-egg transitions |
+| `BOOT_TIMINGS.poweredOnMs` | `3500` | JS clock — content reveal |
+| `BOOT_TIMINGS.redirectMs` | `5000` (env-overridable) | JS clock — route to `/resume` |
+
+These are choreographed: change one, re-derive all, and update this table in the same commit.
+
+### 8.2 Reduced-motion variant — "the fast-boot switch"
+
+Under `@media (prefers-reduced-motion: reduce)` and the matching `matchMedia` branch:
+
+- Single ignite step ≤ **300ms**: screen goes from off to lit with one opacity ease — no flicker, no bloom sweep, no brightness oscillation.
+- JS clocks collapse proportionally: `poweredOnMs → 300`, redirect → `800ms`.
+- Cursor blink becomes a steady block (no `blink` animation).
+- `crt-smack-triple` / `crt-roll-triple` are suppressed entirely; easter eggs cut directly to their mode.
+- Scanlines/vignette/bezel remain — they are static texture, not motion.
+
+The reduced-motion boot is still a *boot* — the screen still turns on. It is the DIP-switch warm start, not a different machine.
+
+## 9. Token Architecture v2
+
+1. **New semantic tokens** on `TerminalColors`: `codeBackground` (Phase 3, all themes — §5.3) and `glow` (Phase 4; a full `text-shadow` value string; `"none"` for dark/light). Adding a token means: TypeScript interface + every theme JSON + `cssDefaults.ts` + this document, in one commit. The theme-completeness test enforces it.
+2. **Canonical-fallback policy:** every `var(--token, fallback)` in a component routes through `web/src/config/cssDefaults.ts`, and the canonical fallback **is the dark-theme value** — a failed token load must render the on-brand default screen. Known drift to fix first: `prompt`/`command` → `#929292`, `brightBlack` → `#333333`.
+3. **Registry-driven names:** `ThemeName` derives from the `themes` registry keys (+ `'auto'`). Exactly one validator, consumed by both `useTheme.loadThemePreference` and the `theme` command. Stale LocalStorage values fall back to dark (existing `getTheme` contract).
+4. **Load-bearing annotations:** a `TOKEN_USAGE` map in `web/src/themes/index.ts`, generated from actual `--color-*` greps, recording which palette keys the UI consumes. JSON cannot carry comments; the map is the annotation.
+
+## 10. Offline Doctrine
+
+*The terminal works when the mainframe is down.* A real terminal didn't stop existing when the modem dropped — and a resume should survive conference-room Wi-Fi.
+
+- **Precache:** the app shell — JS, CSS, fonts, theme JSONs, `example`/resume YAML, the favicon set. Total well under a megabyte.
+- **Never precache:** `public/games/**` (11MB FreeDoom bundle, Zork story file). Runtime `CacheFirst` after first deliberate play, `NetworkOnly` before.
+- **Update flow:** `skipWaiting` + `clientsClaim`; the *only* user-visible signal is a MOTD-style terminal line on next visit (e.g. `System updated. 4 themes available.`). No toast. No refresh button. F-tier rules apply to service-worker UX too.
+- **Manifest:** `name: "kenzik.com"`, `theme_color`/`background_color: #1e1e1e`, CRT-bezel icon set.
+- **Rollback:** `pwa: false` in `quasar.config.js` — one line, documented here so nobody has to rediscover it during an incident.
+
+## 11. Quality Gates
+
+Every phase PR clears all of these before `retro-reviewer` even reads the diff:
+
+| Gate | Threshold |
+|------|-----------|
+| Unit suite | `yarn vitest run` green; theme-completeness covers every registered theme |
+| E2E smoke | boot, `help`, pipe chain, theme switch × all themes, easter-egg entry (class assertion), reduced-motion boot |
+| Screenshot baseline | Default dark home screen: **0-pixel diff** on refactor phases; new baselines only with design-director sign-off |
+| Contrast regression | Light-theme code chips ≥ 4.5:1 (the live bug ships as an expected-fail test until Phase 3 flips it) |
+| Performance budget | Built `dist/spa` JS+CSS transfer ≤ **250KB** (excludes `public/games/**`); current baseline ~180KB — headroom, not a target |
+| Obfuscation | `grep -rE "<trigger words>" web/dist/spa/assets` → empty |
+| Boot timing | Full choreography ~3.5s preserved (one un-shortened e2e test); reduced-motion variant ≤ 300ms ignite |
+
+Then the human gate: `retro-reviewer` verdict with file:line citations, judged against §3.
+
+## 12. Backlog & Non-Goals
+
+**Explicitly out of scope** (so nobody "helpfully" adds them): sound/beep emulation, SSR, additional games, an in-terminal theme editor, telemetry/analytics, auth, comments, dark-mode toggles outside the `theme` command.
+
+**Future backlog, in spirit but unscheduled:** a `P4 white` theme (the full phosphor set), `--terminal-glow` decay animation on text print (true persistence emulation — needs a perf budget conversation), Zork save-state via the PWA cache.
+
+---
+
+*Authored as the Phase 0 charter of `docs/plans/modernization-2026.md`. Token values verified by computed WCAG 2.1 ratios at authoring time. When a phase lands, `design-director` true-ups `DESIGN_GUIDE.md`; this document stays the horizon.*

--- a/docs/plans/create-design-guide.md
+++ b/docs/plans/create-design-guide.md
@@ -1,0 +1,52 @@
+# Plan: Create `DESIGN_GUIDE.md`
+
+## Context
+
+The resume site is a retro-CRT terminal (Vue 3 + Quasar + TypeScript) that was partly "vibe coded" with Cursor/Claude a few months ago. Dave wants a single authoritative design document so that (a) the as-built design system is captured in one place and (b) future AI edits (Cursor/Claude) stay on-brand, and (c) the design can *eventually* be modernized without losing the retro look/feel.
+
+Per the two scope answers, the guide is **Document + Modernize**, optimized as **AI-agent context** (tokens, file paths, semantic rules, do/don't constraints — plus a modernization section naming the vibe-coding artifacts with retro-preserving fixes).
+
+**Deliverable:** a new `DESIGN_GUIDE.md` at the repo root (`/Volumes/ARCHIVE/Source/kenzik/resume/DESIGN_GUIDE.md`). This is a documentation-only task — no source files change.
+
+## Source of truth (verified during exploration)
+
+The guide is assembled from these real files/values — every claim must trace to one:
+
+- **Themes/colors:** `web/src/themes/dark.json`, `web/src/themes/light.json`; applier `web/src/composables/useTheme.ts` (default `'auto'`, persists to `kenzik-resume-theme`, follows `prefers-color-scheme`). CSS vars: `--color-*` (full ANSI palette) and `--terminal-*` (semantic: prompt/command/output/error/success/warning/info).
+- **Fonts/type:** `web/src/config/fonts.json` (10 fonts, default **Fira Code**, size 18 / line-height 1.6), `web/src/composables/useFont.ts` (sets `--font-family`, `--font-size`, `--font-line-height`; per-font persisted size 8–32px & spacing 0.5–3.0), `font` command in `web/src/commands/settings.ts`. Markdown scale in `Terminal.vue`: h1 1.4em / h2 1em / h3 0.75em.
+- **CRT frame:** `web/src/components/CRTFrame.vue` — layered inset bezel shadows, radial-gradient glass curve, scanline `repeating-linear-gradient` (1px/3px), vignette, z-index 99/100.
+- **Power-on warm-up:** `web/src/pages/Landing.vue` — keyframes `powerLineAppear`, `powerLineExpand`, `powerLineFlicker`, `phosphorWarmup`, `screenWarmup`; ~3.5s warm-up, 5s redirect; `--terminal-success` (#23d18b) phosphor green.
+- **Layout/motion:** `web/src/components/Terminal.vue` (~2200 lines) — terminal padding 20/14/10px, `blink` cursor keyframe, `crt-smack-triple`/`crt-roll-triple` 1.8s transitions, phosphor `box-shadow` glow; prompt in `TerminalPrompt.vue` (`dave@resume:~$`). Typewriter speeds in `web/src/constants/index.ts` (`TYPEWRITER_SPEEDS`).
+- **Global tokens:** `web/src/css/app.scss` (`--terminal-max-width:1200px`, `--terminal-max-height:900px`, bezel shadow, mobile breakpoints 768/480).
+
+## Document structure
+
+1. **Design Philosophy** — retro CRT terminal; "earnest emulation, not parody"; the boot ritual (off → warm-up line → phosphor glow → scroll-in) as the signature moment; constraint: every change must preserve the retro feel.
+2. **Color System** — the two themes + `auto`; full token table mapping `--color-*` and `--terminal-*` to roles and the dark/light values; the observed on-screen roles (amber heading, cyan/blue subtitle, green section headers + highlights, grey body, grey prompt) tied to their tokens; **rule:** never hardcode hex in components — use tokens.
+3. **Typography** — 10-font roster table (family, source, self-hosted vs Google vs system), Fira Code default, the type scale, per-font size/spacing persistence, the `font` command.
+4. **CRT Visual Language** — bezel layers, glass curve, scanlines, vignette, phosphor glow; the exact values and z-index stack.
+5. **Motion & Boot Sequence** — the warm-up keyframe timeline with timings; cursor blink; typewriter speeds; smack/roll transitions and when they fire.
+6. **Layout & Responsive** — terminal dimensions, padding, the three breakpoints (desktop/768/480), mobile-specific behavior (native caret, 16px input to block iOS zoom).
+7. **Token Reference (appendix)** — flat list of every CSS custom property with file origin, for fast AI lookup.
+8. **Do / Don't for AI edits** — e.g. *Do* read tokens from `useTheme`/`useFont`; *Don't* add a third theme without populating both ANSI + terminal blocks; *Don't* break the 4-space monospace rhythm; keep phosphor green `#23d18b` for power-on.
+9. **Modernization Opportunities (retro-preserving)** — names the vibe-coding artifacts and proposes fixes that keep the look:
+   - **Scattered hardcoded fallbacks** (`var(--x, #hex)` duplicated everywhere, drift risk) → centralize defaults (`web/src/config/cssDefaults.ts` already exists — lean on it) and/or document one canonical fallback set.
+   - **Monolithic `Terminal.vue` (~2200 lines mixing logic + 600 lines of SCSS)** → extract CRT/transition SCSS into a partial or dedicated style module; note this is the biggest "vibe" artifact.
+   - **Magic numbers in keyframes/animations** (timings, scaleY steps, translate px) → name them as SCSS/CSS variables (`--crt-warmup-duration`, etc.).
+   - **Mixed units** (`px` vs `rem` vs `em` vs unitless) → state a unit convention.
+   - **Unused/duplicated palette** (full ANSI block defined but few colors used; bright vs base overlap) → document which tokens are actually load-bearing.
+   - **Two-theme ceiling** → note the path to add CRT-authentic themes (amber P3 phosphor, green P1) since the token architecture already supports it.
+   Each item: *what it is → why it reads as vibe-coded → minimal retro-safe fix*. Framed as a backlog, not prescriptive refactors.
+
+## Files
+
+- **Create:** `/Volumes/ARCHIVE/Source/kenzik/resume/DESIGN_GUIDE.md` (only file created).
+- **Modify:** none.
+- Optionally add a one-line pointer to `DESIGN_GUIDE.md` under "Key Files" in `CLAUDE.md` — **ask/skip**; not required, and CLAUDE.md is checked in. Default: leave CLAUDE.md untouched unless requested.
+
+## Verification
+
+- Render-check the Markdown (tables, code fences) — `npx markdownlint DESIGN_GUIDE.md` if available, else visual scan.
+- Spot-verify ≥5 cited values against source (e.g. Fira Code default in `fonts.json:2`, `#23d18b` in `Landing.vue`, `--terminal-max-width:1200px` in `app.scss`) so no number is invented.
+- Confirm every file path referenced in the guide exists (`ls` each).
+- No build/test impact since no source changes; `yarn build` is not required for a docs-only addition.

--- a/docs/plans/modernization-2026.md
+++ b/docs/plans/modernization-2026.md
@@ -1,0 +1,94 @@
+# Plan: Modernize kenzik.com (Retro-Preserving) with a Persisted Subagent Team
+
+## Context
+
+kenzik.com is a retro-CRT terminal resume (Vue 3.4 + Quasar 2.14 + TS strict, Cloudflare Pages). DESIGN_GUIDE.md §9 names a "vibe-coded" modernization backlog. Dave wants it executed — **full scope**: architecture refactor, visual evolution, UX/a11y, and new capabilities — by a **persisted roster of project subagents** (opus + sonnet families) in `.claude/agents/`, guided by a new **companion vision doc `DESIGN_GUIDE_2026-2.md`**, with a **Vitest + Playwright** safety net added first. Prime directive holds: every change reads as earnest CRT emulation; zero visual regression on default dark theme; the ~3.5s boot ritual is preserved except under `prefers-reduced-motion`.
+
+**Post-approval step:** copy this plan to `docs/plans/modernization-2026.md` in the repo.
+
+## Live-site & code findings driving the plan (verified)
+
+- **BUG (light theme):** inline code chips render `--color-brightGreen`-text-on-`--color-brightBlack` boxes — unreadable. Root cause `Terminal.vue:2044` `background: var(--color-brightBlack, #666666)`; needs a new semantic `terminal.codeBackground` token (brightBlack is also load-bearing for borders at `Terminal.vue:1979,2110`).
+- **DESIGN_GUIDE §9.7 is wrong that new themes are "no code changes":** `ThemeName` union hardcoded at `themes/index.ts:54`, whitelists at `useTheme.ts:46` and `commands/settings.ts:60` — must become registry-driven.
+- **`cssDefaults.ts` has drift** (`prompt/command: #0dbc79/#3b8eea` vs dark's `#929292`; `brightBlack #666666` vs `#333333`) — fix to dark-theme canon before centralizing fallbacks.
+- **Boot is dual-clocked:** CSS keyframes (`Landing.vue:175-300`) + JS timers (`Landing.vue:46-60`, 3500ms / `VITE_POWER_ON_DELAY_MS` 5000 redirect). Reduced-motion must branch both.
+- No `aria-label` on terminal inputs (`Terminal.vue:57,98`); modals already have dialog ARIA. No tests anywhere. PWA block dormant at `quasar.config.js:158-173`. 11MB `public/games/doom/freedoom.jsdos` must never be precached. Perf is healthy (180KB transfer, 0 console errors). `data/kenzik.yml` is gitignored — tests use `data/example.yml`.
+
+## 1. Subagent roster — `.claude/agents/*.md` (7 files)
+
+Format: markdown + YAML frontmatter (`name`, `description`, `model`, `tools`). Opus = judgment/taste; sonnet = well-specified mechanics.
+
+| Agent | Model | Role |
+|---|---|---|
+| `design-director` | **opus** | Authors DESIGN_GUIDE_2026-2.md; produces exact token tables (amber P3, green P1, codeBackground) with WCAG figures; specs reduced-motion boot; adjudicates "does this read as CRT?". Never edits runtime code. Tools: Read, Glob, Grep, Write, Edit, WebSearch, WebFetch |
+| `crt-effects-engineer` | **opus** | Named animation constants (`--crt-*` vars, new `css/crt-timing.scss`); extracts smack/roll keyframes to `css/crt-effects.scss`; reduced-motion boot visuals; `@supports`-gated modern CSS (OKLCH, view transitions) only where pixel-identical. Tools: Read, Glob, Grep, Edit, Write, Bash |
+| `refactor-surgeon` | **sonnet** | Decomposes Terminal.vue (SCSS out first, then optional TerminalOutput.vue); centralizes `var(--x, #hex)` fallbacks through fixed cssDefaults.ts; removes dead `font.lineHeight`; annotates load-bearing tokens. One mechanical move per commit; never changes a rendered value. Tools: Read, Glob, Grep, Edit, Write, Bash |
+| `theme-smith` | **sonnet** | Implements design-director's token tables: `terminal.codeBackground` (light-theme bug fix), `themes/amber.json` + `green.json`, registry-driven `ThemeName` + validation in useTheme/settings. Tools: Read, Glob, Grep, Edit, Write, Bash |
+| `a11y-engineer` | **sonnet** | ARIA on inputs, `role="log"`/`aria-live` evaluation on output, focus restoration after modals, keyboard hint line, reduced-motion media-query wiring + verification. Tools: Read, Glob, Grep, Edit, Write, Bash |
+| `test-engineer` | **sonnet** | Vitest (standalone config, happy-dom, quasar mocks; composables/commands/utils + theme-completeness test) and Playwright smoke (boot, help, pipe, theme×4, easter-egg smack/roll class, contrast regression, reduced-motion via emulateMedia); screenshot baselines; `.github/workflows/test.yml`; perf budget gate (app JS+CSS ≤250KB, `games/**` excluded). Tools: Read, Glob, Grep, Edit, Write, Bash |
+| `retro-reviewer` | **opus** | Read-only gate on every PR: diff vs DESIGN_GUIDE §8 + 2026-2 tier list; screenshot baseline comparison; dist grep for plaintext easter-egg triggers; boot-timing check; written verdict with file:line citations. Tools: Read, Glob, Grep, Bash |
+
+**Orchestration playbook** (included in plan doc): main thread is conductor; never two agents on Terminal.vue concurrently; handoff artifacts live in DESIGN_GUIDE_2026-2.md (not chat memory); every phase ends with tests green → retro-reviewer verdict → PR to `development` (conventional commits); implementing agents escalate spec-vs-retro conflicts to design-director rather than improvising; Phase 0 ∥ Phase 1 parallel-safe, 2→3→4 serial, 5 ∥ 4.
+
+## 2. Phases & PR map (branch off `development`)
+
+| # | PR | Agent(s) | Contents | Why this order |
+|---|---|---|---|---|
+| 0 | `docs: add 2026 design vision and agent roster` | design-director | 7 `.claude/agents/*.md` + `DESIGN_GUIDE_2026-2.md` | Downstream agents implement *from* the guide |
+| 1 | `test: add vitest unit + playwright smoke suites and CI` | test-engineer | `web/vitest.config.ts`, `web/playwright.config.ts`, `web/test/**`, devDeps, `.github/workflows/test.yml`, screenshot baselines. Contrast test lands as expected-fail documenting the bug. Playwright sets `VITE_POWER_ON_DELAY_MS` low except one full-boot test | Refactor is only safe with baselines locked |
+| 2 | `refactor: decompose Terminal.vue and centralize CSS fallbacks` | refactor-surgeon + crt-effects-engineer | SCSS → `css/{terminal,crt-effects,crt-timing}.scss`; named timing vars + `BOOT_TIMINGS` in `constants/index.ts`; cssDefaults drift fixed then fallback sweep; dead `font.lineHeight` removed; token-usage annotations; (stretch) `TerminalOutput.vue` | Gate: 0-px screenshot diff; obfuscation grep clean |
+| 3 | `fix: light-theme code chips, reduced-motion boot, terminal ARIA` | a11y-engineer + crt-effects-engineer + theme-smith | `terminal.codeBackground` token (flip contrast test to pass); input ARIA + focus restore; reduced-motion fast boot (≤300ms ignite, CSS + JS timer branch); keyboard hint | Needs Phase 2's extracted SCSS/central defaults |
+| 4 | `feat: amber P3 and green P1 phosphor themes` | theme-smith + crt-effects-engineer (+ design-director sign-off) | `themes/{amber,green}.json` (all blocks; completeness test enforces); registry-driven ThemeName/validation; optional `--terminal-glow` token (default `none` — preserves "no glow on default text"); `@supports`-gated OKLCH / view-transition re-tint | Themes must include codeBackground from day one |
+| 5 | `feat: enable PWA offline mode and CI performance budget` | test-engineer + refactor-surgeon | Quasar PWA mode (`src-pwa/`, manifest, icons); `generateSW` with `globIgnores: ['games/**']`; update notice as MOTD line (no toasts); perf budget blocking in CI. Rollback = `pwa: false` | Parallel with 4 after 2; soak on preview deploy |
+| 6 | `docs: sync DESIGN_GUIDE.md with as-built changes` | design-director | True-up as-built guide + CLAUDE.md Key Files (stale: points at useCommands.ts instead of `commands/` registry) | Last, reflects reality |
+
+## 3. Critical files
+
+- `web/src/components/Terminal.vue` — decomposition target; bug at :2044; ARIA at :57/:98; smack/roll keyframes :1623-1834
+- `web/src/themes/index.ts` (:54 ThemeName union), `web/src/composables/useTheme.ts` (:46), `web/src/commands/settings.ts` (:60) — registry-driven validation
+- `web/src/config/cssDefaults.ts` — fix drift, then becomes fallback SSOT
+- `web/src/pages/Landing.vue` — boot keyframes :175-300, JS timers :46-60
+- `web/quasar.config.js` — obfuscate plugin (:140), dormant PWA block (:158-173)
+- New: `web/src/css/{terminal,crt-effects,crt-timing}.scss`, `web/src/themes/{amber,green}.json`, `web/test/**`, `web/src-pwa/**`, `.claude/agents/*.md`, `DESIGN_GUIDE_2026-2.md`, `.github/workflows/test.yml`
+
+## 4. DESIGN_GUIDE_2026-2.md outline
+
+1. Charter & relationship to DESIGN_GUIDE.md (companion; as-built guide stays truth; code wins)
+2. Prime Directive 2026: "would a 1980s phosphor monitor do this?" + "would a 2026 browser let us fake it for free?"
+3. **CRT Authenticity Tier List** — S: boot ritual / phosphor palette / monospace grid (untouchable); A: scanlines, vignette, bezel (tunable within alpha limits); B: smack/roll, glow (easter-egg-only); F: toasts, spinners, parallax (forbidden) — retro-reviewer's rubric
+4. **Phosphor Physics Primer** — P1 green / P3 amber / P4 white; persistence→glow decay, bloom→text-shadow radii, temperature→background tint, mapped to tokens
+5. **Theme Specifications** — full token tables for amber & green incl. codeBackground + glow, WCAG AA figures; `auto` still resolves only dark/light
+6. **Modern CSS Under the Retro Skin** doctrine — OKLCH, `@property`, View Transitions, container queries; iron rule: `@supports`-gated + pixel-identical-or-invisible
+7. **Accessibility as Period-Correct Feature** — reduced-motion = the "fast boot" DIP switch real terminals had; ARIA mapping table; keyboard-first as the native model
+8. **Motion Spec v2** — named `--crt-*` timeline table (~3.5s) + reduced-motion variant (≤300ms, no flicker)
+9. **Token Architecture v2** — codeBackground/glow semantics, canonical-fallback policy (= dark theme), load-bearing annotations, registry-driven names
+10. **Offline Doctrine** — "the terminal works when the mainframe is down"; precache app shell, never games; update-as-MOTD
+11. **Quality Gates** — ≤250KB app transfer, test matrix, screenshot policy, obfuscation smoke check
+12. **Backlog & Non-Goals** — out: sound, SSR, more games, theme editor
+
+## 5. Verification per phase
+
+| Phase | Checks |
+|---|---|
+| 0 | markdownlint (optional); `/agents` lists 7; sanity-read token tables |
+| 1 | `cd web && yarn lint && yarn vitest run && yarn playwright test && yarn build`; baselines match live; contrast test xfail |
+| 2 | Full suite, 0-diff screenshots; `grep -rE "xyzzy|iddqd|plugh" web/dist/spa/assets` → empty; manual dark+light pass (boot, help, pipe, xyzzy smack/roll, mobile) |
+| 3 | Contrast test now passes; reduced-motion e2e via `emulateMedia({reducedMotion:'reduce'})`; axe-core/VoiceOver spot check; normal boot still ~3.5s |
+| 4 | Theme-completeness covers 4 themes; LocalStorage migration (`amber` survives reload, garbage falls back); dark default 0-diff; new baselines |
+| 5 | PWA build + Lighthouse installable; offline reload works; precache excludes `games/**`; perf gate green; preview deploy unaffected |
+
+Every PR gets a retro-reviewer verdict before merge.
+
+## 6. Top risks
+
+1. **Terminal.vue split regression** (cursor px math, mobile/desktop branches, pager/game modes) → tests-first, SCSS-only extraction before script moves, one move per commit (bisectable), 0-diff gate, stretch goals droppable.
+2. **Quasar+Vitest quirks** (LocalStorage/useMeta imports, app-vite owns vite config) → standalone vitest.config.ts, `vi.mock('quasar')`, lean on Playwright for integration.
+3. **Token blast radius** (missed key = silent fallback) → `TerminalColors` interface makes omissions compile errors + completeness test; canonical fallback = on-brand dark values anyway.
+4. **Theme persistence/validation paths** (hardcoded whitelists, stale LocalStorage, `auto` semantics) → single registry validator + explicit unit tests.
+5. **PWA staleness / asset bloat** (11MB doom; SW vs Cloudflare cache) → `globIgnores: ['games/**']`, skipWaiting+clientsClaim with MOTD, ship last + soak on preview, one-line rollback.
+
+## Execution kickoff (after approval)
+
+1. `mkdir -p docs/plans` (exists) and copy this plan → `docs/plans/modernization-2026.md`.
+2. Branch `feature/modernization-2026-charter` off `development`; run Phase 0 (roster + vision doc); PR.
+3. Proceed phase-by-phase per §2, conducting subagents per the playbook.


### PR DESCRIPTION
## Phase 0 — Modernization Charter

Kickoff PR of the retro-preserving modernization plan (`docs/plans/modernization-2026.md`).

### What's in here (docs + agent config only — zero runtime change)

- **`DESIGN_GUIDE.md`** — the as-built design system (single source of truth for the current look)
- **`DESIGN_GUIDE_2026-2.md`** — the forward vision: CRT Authenticity Tier List, phosphor physics primer, full token specs for the upcoming **Amber P3** and **Green P1** themes (all WCAG ratios computed, not estimated), reduced-motion "fast-boot DIP switch" spec, offline doctrine, and quality gates
- **`.claude/agents/`** — 7 persisted project subagents with opus/sonnet model assignments:
  | Agent | Model |
  |---|---|
  | design-director, crt-effects-engineer, retro-reviewer | opus |
  | refactor-surgeon, theme-smith, a11y-engineer, test-engineer | sonnet |
- **`docs/plans/`** — the approved modernization plan (6 phases, PR-per-phase) and the earlier design-guide plan
- **`.gitignore`** — ignore `.claude/settings.local.json`, newline fix

### Notable findings baked into the plan
- Live light-theme bug: inline code chips render at **2.20:1** contrast (unreadable); spec'd fix reaches 10.31:1 (Phase 3)
- DESIGN_GUIDE §9.7's "new themes need no code changes" is wrong — `ThemeName` union + two validation whitelists must become registry-driven (Phase 4)
- `cssDefaults.ts` fallback drift documented; canonical-fallback policy = dark-theme values

### Next phases
1. `test:` Vitest + Playwright safety net 2. `refactor:` Terminal.vue decomposition 3. `fix:` light-theme chips + reduced-motion + ARIA 4. `feat:` phosphor themes 5. `feat:` PWA + perf budget 6. `docs:` true-up
